### PR TITLE
Add GitHub Skills activity to signup page

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills using GitHub, part of the GitHub Certifications program",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 30,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the **GitHub Skills** activity to the school activities signup page, as requested in issue #6.

## Changes

- Added "GitHub Skills" to the in-memory activities dictionary in `src/app.py`
  - **Description:** Learn practical coding and collaboration skills using GitHub, part of the GitHub Certifications program
  - **Schedule:** Mondays and Wednesdays, 3:30 PM - 4:30 PM
  - **Max participants:** 30

## Motivation

The principal announced a new partnership with GitHub to teach students practical coding and collaboration skills. Students need to be able to register before the end of this week.

Closes #6